### PR TITLE
Various Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Cavhold
+Modified Foothold file. Originally created by
+
+Modified by:
+MacMillan.M
+Langlois.R
+Young.K

--- a/l10n/DEFAULT/ATIS.lua
+++ b/l10n/DEFAULT/ATIS.lua
@@ -1,4 +1,7 @@
 -- ATIS Anapa Airport on 143.00 MHz AM.
-atisAnapa=ATIS:New(AIRBASE.Caucasus.Anapa_Vityazevo, 143.00)
-atisAnapa:SetTowerFrequencies({121, 250})
-atisAnapa:Start()
+
+-- TODO: Revisit to enable ATIS but respect FC3 radio
+-- Disabling due to FC3 aircraft not being able to turn ATIS off
+-- atisAnapa=ATIS:New(AIRBASE.Caucasus.Anapa_Vityazevo, 143.00)
+-- atisAnapa:SetTowerFrequencies({121, 250})
+-- atisAnapa:Start()

--- a/l10n/DEFAULT/dictionary
+++ b/l10n/DEFAULT/dictionary
@@ -67,7 +67,6 @@ You can earn credits in several ways:\
 \
 The red coalition will use credits earned from controlling certain zones to call in its own support.\
 \
-ATIS (Anapa): 143.000 \
 CTAF/ATC Comms: 305.000  \
 A2A Comms: 306.000 \
 A2G Comms: 307.000 \
@@ -98,7 +97,7 @@ Shell 1-1 MPRS:\
 Freq: 256.0 MHz AM\
 TCN: 16X\
 \
-Shell 1-2 MPRS:\
+Shell 2-1 MPRS:\
 Freq: 257.0 MHz AM\
 TCN: 17X\
 \
@@ -106,7 +105,7 @@ Texaco 1-1 KC135:\
 Freq: 258.0 MHz AM\
 TCN: 18X\
 \
-Texaco 1-2 KC135:\
+Texaco 2-1 KC135:\
 Freq: 259.0 MHz AM\
 TCN: 19X\
 \

--- a/options
+++ b/options
@@ -1,19 +1,19 @@
 options = 
 {
-    ["playerName"] = "Outcast 1-1",
+    ["playerName"] = "New callsign",
     ["miscellaneous"] = 
     {
         ["chat_window_at_start"] = true,
         ["TrackIR_external_views"] = true,
         ["f11_free_camera"] = true,
         ["f10_awacs"] = true,
-        ["Coordinate_Display"] = "Precise Lat Long",
+        ["Coordinate_Display"] = "Lat Long",
         ["accidental_failures"] = false,
         ["autologin"] = true,
         ["show_pilot_body"] = false,
-        ["collect_stat"] = true,
+        ["collect_stat"] = false,
         ["synchronize_controls"] = false,
-        ["backup"] = true,
+        ["backup"] = false,
         ["headmove"] = false,
         ["f5_nearest_ac"] = true,
         ["F2_view_effects"] = 1,
@@ -42,10 +42,10 @@ options =
         ["cockpitStatusBarAllowed"] = false,
         ["wakeTurbulence"] = false,
         ["easyFlight"] = false,
-        ["hideStick"] = true,
+        ["hideStick"] = false,
         ["radio"] = false,
         ["geffect"] = "realistic",
-        ["easyCommunication"] = false,
+        ["easyCommunication"] = true,
         ["reports"] = true,
         ["units"] = "imperial",
         ["unrestrictedSATNAV"] = false,
@@ -55,7 +55,7 @@ options =
         ["RBDAI"] = true,
         ["tips"] = true,
         ["userMarks"] = true,
-        ["labels"] = 4,
+        ["labels"] = 0,
     }, -- end of ["difficulty"]
     ["VR"] = 
     {
@@ -66,7 +66,7 @@ options =
         ["hand_controllers_use_throttle"] = true,
         ["hand_controllers_debug_draw"] = false,
         ["mirror_crop"] = false,
-        ["prefer_built_in_audio"] = false,
+        ["prefer_built_in_audio"] = true,
         ["pixel_density"] = 1,
         ["hand_controllers_use_stick"] = true,
         ["msaaMaskSize"] = 0.42,
@@ -75,63 +75,85 @@ options =
         ["bloom"] = true,
         ["mirror_source"] = 0,
         ["custom_IPD"] = 63.5,
-        ["hand_controllers"] = false,
+        ["hand_controllers"] = true,
     }, -- end of ["VR"]
     ["graphics"] = 
     {
         ["messagesFontScale"] = 1,
-        ["forestDetailsFactor"] = 1,
+        ["forestDetailsFactor"] = 0.75,
         ["rainDroplets"] = true,
         ["LensEffects"] = 3,
         ["box_mouse_cursor"] = false,
-        ["anisotropy"] = 4,
+        ["anisotropy"] = 2,
         ["water"] = 2,
         ["motionBlur"] = 0,
-        ["visibRange"] = "High",
-        ["aspect"] = 2.3888888888889,
+        ["visibRange"] = "Ultra",
+        ["aspect"] = 1.3333333333333,
         ["lights"] = 2,
-        ["shadows"] = 4,
-        ["MSAA"] = 1,
-        ["SSAA"] = 0,
+        ["shadows"] = 2,
+        ["MSAA"] = 2,
+        ["SSAA"] = 1,
         ["civTraffic"] = "",
-        ["forestDistanceFactor"] = 0.7,
-        ["cockpitGI"] = 1,
+        ["forestDistanceFactor"] = 1,
+        ["cockpitGI"] = 0,
         ["terrainTextures"] = "max",
         ["multiMonitorSetup"] = "1camera",
         ["shadowTree"] = false,
         ["chimneySmokeDensity"] = 1,
         ["fullScreen"] = false,
-        ["DOF"] = 1,
+        ["DOF"] = 0,
         ["clouds"] = 3,
-        ["sceneryDetailsFactor"] = 1,
+        ["sceneryDetailsFactor"] = 0.9,
         ["textures"] = 2,
         ["useDeferredShading"] = 1,
         ["outputGamma"] = 1.6,
-        ["flatTerrainShadows"] = 0,
-        ["width"] = 3440,
-        ["SSLR"] = 1,
-        ["secondaryShadows"] = 1,
-        ["SSAO"] = 1,
+        ["flatTerrainShadows"] = 2,
+        ["width"] = 1920,
+        ["SSLR"] = 0,
+        ["secondaryShadows"] = 0,
+        ["SSAO"] = 0,
         ["heatBlr"] = 1,
         ["sync"] = false,
-        ["preloadRadius"] = 30200,
+        ["preloadRadius"] = 34600,
         ["effects"] = 3,
         ["scaleGui"] = 1,
-        ["clutterMaxDistance"] = 700,
-        ["height"] = 1440,
+        ["clutterMaxDistance"] = 370,
+        ["height"] = 1080,
     }, -- end of ["graphics"]
     ["plugins"] = 
     {
-        ["CA"] = 
+        ["Su-25T"] = 
         {
-            ["kompass_options"] = 1,
-            ["ground_platform_shake"] = true,
-            ["ground_target_info"] = true,
-            ["ground_aim_helper"] = true,
-            ["ground_engine_autostart"] = true,
-            ["ground_automatic"] = true,
-            ["ground_isometric"] = true,
-        }, -- end of ["CA"]
+            ["CPLocalList"] = "English",
+        }, -- end of ["Su-25T"]
+        ["DCS-SRS"] = 
+        {
+            ["srsOverlayHelpTextEnabled"] = true,
+            ["srsOverlayEnabled"] = true,
+            ["srsAutoLaunchEnabled"] = true,
+            ["srsOverlayCompactModeEnabled"] = false,
+        }, -- end of ["DCS-SRS"]
+        ["Ka-50"] = 
+        {
+            ["Ka50TrimmingMethod"] = 0,
+            ["Ka50RudderTrimmer"] = false,
+            ["hmdEye"] = 1,
+            ["CPLocalList"] = "default",
+            ["helmetCircleDisplacement"] = 11,
+        }, -- end of ["Ka-50"]
+        ["F/A-18C"] = 
+        {
+            ["abDetent"] = 0,
+            ["canopyReflections"] = 0,
+            ["hmdEye"] = 1,
+            ["CPLocalList"] = "default",
+            ["F18RealisticTDC"] = true,
+            ["mfdReflections"] = 0,
+        }, -- end of ["F/A-18C"]
+        ["Hercules"] = 
+        {
+            ["NWS_Coupled_Separate_Input_Device"] = false,
+        }, -- end of ["Hercules"]
         ["CaptoGlove"] = 
         {
             ["shoulderJointZ_Right"] = 23,
@@ -160,36 +182,45 @@ options =
             ["shoulderJointY_Right"] = -23,
             ["yawOffsetGlove_Right"] = 0,
         }, -- end of ["CaptoGlove"]
-        ["F-16C"] = 
+        ["AH-64D_BLK_II"] = 
         {
-            ["abDetent"] = 0,
-            ["canopyReflections"] = 0,
-            ["hmdEye"] = 1,
+            ["AH64BalaclavaPLT"] = true,
+            ["AH64HmdEye"] = 1,
             ["CPLocalList"] = "default",
-            ["canopyTint"] = 1,
-            ["mfdReflections"] = 0,
-        }, -- end of ["F-16C"]
-        ["F/A-18C"] = 
+            ["AH64BalaclavaCPG"] = true,
+            ["AH64CyclicTrimmingMethod"] = 0,
+            ["AH64PedalsTrimmingMethod"] = 0,
+            ["AH64TriggerGuardEnable"] = false,
+            ["AH64CockpitShake"] = 50,
+            ["AH64LockoutDetent"] = 1,
+            ["AH64AIColorScheme"] = 0,
+            ["AH64AutoHandover"] = true,
+            ["AH64IhadssMonocleVisible"] = true,
+        }, -- end of ["AH-64D_BLK_II"]
+        ["Tacview"] = 
         {
-            ["abDetent"] = 2,
-            ["canopyReflections"] = 0,
-            ["hmdEye"] = 1,
-            ["CPLocalList"] = "default",
-            ["F18RealisticTDC"] = true,
-            ["mfdReflections"] = 0,
-        }, -- end of ["F/A-18C"]
-        ["Hercules"] = 
+            ["tacviewExportPath"] = "",
+            ["tacviewDebugMode"] = 0,
+            ["tacviewRemoteControlPort"] = "42675",
+            ["tacviewFlightDataRecordingEnabled"] = true,
+            ["tacviewRealTimeTelemetryPassword"] = "",
+            ["tacviewSinglePlayerFlights"] = 2,
+            ["tacviewTerrainExport"] = 0,
+            ["tacviewAutoDiscardFlights"] = 10,
+            ["tacviewRemoteControlPassword"] = "",
+            ["tacviewRealTimeTelemetryPort"] = "42674",
+            ["tacviewBookmarkShortcut"] = 0,
+            ["tacviewRemoteControlEnabled"] = false,
+            ["tacviewRealTimeTelemetryEnabled"] = true,
+            ["tacviewMultiplayerFlightsAsHost"] = 2,
+            ["tacviewMultiplayerFlightsAsClient"] = 2,
+            ["tacviewModuleEnabled"] = true,
+        }, -- end of ["Tacview"]
+        ["Supercarrier"] = 
         {
-            ["NWS_Coupled_Separate_Input_Device"] = false,
-        }, -- end of ["Hercules"]
-        ["A-4E-C"] = 
-        {
-            ["cssActivate"] = 15,
-            ["trimSpeed"] = 0,
-            ["cockpitShake"] = 100,
-            ["oldRadar"] = false,
-            ["wheelBrakeAssist"] = false,
-        }, -- end of ["A-4E-C"]
+            ["enable_FLOLS_overlay"] = true,
+            ["Use_native_ATC_text"] = false,
+        }, -- end of ["Supercarrier"]
         ["LeapMotion"] = 
         {
             ["handUseThrottle"] = false,
@@ -199,20 +230,16 @@ options =
             ["pointerUseType"] = 0,
             ["handUseStick"] = false,
         }, -- end of ["LeapMotion"]
+        ["Su-33"] = 
+        {
+            ["CPLocalList"] = "default",
+        }, -- end of ["Su-33"]
         ["TF-51D"] = 
         {
             ["assistance"] = 100,
             ["CPLocalList"] = "default",
             ["autoRudder"] = false,
         }, -- end of ["TF-51D"]
-        ["Su-33"] = 
-        {
-            ["CPLocalList"] = "default",
-        }, -- end of ["Su-33"]
-        ["UH-60L"] = 
-        {
-            ["UNSPRUNG_CYCLIC"] = false,
-        }, -- end of ["UH-60L"]
         ["VRFree"] = 
         {
             ["handUseThrottle"] = false,
@@ -221,29 +248,17 @@ options =
             ["enable"] = false,
             ["mouseClickSrc"] = 0,
         }, -- end of ["VRFree"]
-        ["Supercarrier"] = 
+        ["UH-60L"] = 
         {
-            ["enable_FLOLS_overlay"] = true,
-            ["Use_native_ATC_text"] = false,
-        }, -- end of ["Supercarrier"]
-        ["Su-25T"] = 
-        {
-            ["CPLocalList"] = "default",
-        }, -- end of ["Su-25T"]
-        ["DCS-SRS"] = 
-        {
-            ["srsOverlayHelpTextEnabled"] = true,
-            ["srsOverlayEnabled"] = true,
-            ["srsAutoLaunchEnabled"] = true,
-            ["srsOverlayCompactModeEnabled"] = false,
-        }, -- end of ["DCS-SRS"]
+            ["UNSPRUNG_CYCLIC"] = false,
+        }, -- end of ["UH-60L"]
     }, -- end of ["plugins"]
     ["format"] = 1,
     ["sound"] = 
     {
         ["main_output"] = "",
         ["FakeAfterburner"] = true,
-        ["volume"] = 50,
+        ["volume"] = 81,
         ["headphones_on_external_views"] = true,
         ["subtitles"] = true,
         ["world"] = 100,
@@ -256,9 +271,9 @@ options =
         ["voice_chat"] = false,
         ["microphone_use"] = 2,
         ["GBreathEffect"] = true,
-        ["switches"] = 124,
+        ["switches"] = 144,
         ["play_audio_while_minimized"] = false,
-        ["headphones"] = 100,
+        ["headphones"] = 75,
         ["music"] = 0,
         ["voice_chat_input"] = "",
         ["gui"] = 100,
@@ -267,7 +282,7 @@ options =
     {
         ["cockpit"] = 
         {
-            ["mirrors"] = true,
+            ["mirrors"] = false,
             ["reflections"] = false,
             ["avionics"] = 3,
         }, -- end of ["cockpit"]


### PR DESCRIPTION
Fixed:
- Disable script to enable for Anapa ATIS: It cannot be turned off for FC3 players via radio.
- Correct ME for tanker Tex 1-2 radio to set to 259.00 MHz, instead of 258 MHz, which is shared by Tex 1-1
- Moved Anapa-4 spawn for SAM NASAM to southeast to prevent NASAM from blocking taxiway, especially for larger airframes
- Move Apaches at Echo away from hazards (radio tower, building)
- Added ammo and fuel at Krymsk FARP for the UH-60L
- Made helicopters at FARP at Anapa and Krymsk take off from ramp instead of take off from ground
- Rename Texaco, Shell 1-2 to 2-1 to match callsign, this fixes refueling radio.